### PR TITLE
Fix old message only show when restart app after restore KeyBackup

### DIFF
--- a/ClearKeep/Modules/Room/CKRoomViewController.swift
+++ b/ClearKeep/Modules/Room/CKRoomViewController.swift
@@ -269,6 +269,8 @@ extension CKRoomViewController {
             self.bubblesTableView.setContentOffset(CGPoint(x: -self.bubblesTableView.mxk_adjustedContentInset.left, y: -self.bubblesTableView.mxk_adjustedContentInset.top), animated: true)
 
         })
+         
+        self.roomDataSource?.reload()
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Fix old message only show when restart app after restore KeyBackup


### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [ ] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.rst#sign-off)